### PR TITLE
Fix typo in log message, configuraion -> configuration

### DIFF
--- a/src/main/java/org/codehaus/mojo/exec/ExecJavaMojo.java
+++ b/src/main/java/org/codehaus/mojo/exec/ExecJavaMojo.java
@@ -241,7 +241,7 @@ public class ExecJavaMojo
     {
         if ( isSkip() )
         {
-            getLog().info( "skipping execute as per configuraion" );
+            getLog().info( "skipping execute as per configuration" );
             return;
         }
         if ( killAfter != -1 )

--- a/src/main/java/org/codehaus/mojo/exec/ExecMojo.java
+++ b/src/main/java/org/codehaus/mojo/exec/ExecMojo.java
@@ -217,7 +217,7 @@ public class ExecMojo
     {
         if ( isSkip() )
         {
-            getLog().info( "skipping execute as per configuraion" );
+            getLog().info( "skipping execute as per configuration" );
             return;
         }
 


### PR DESCRIPTION
Simple typo fix I noticed last week in our log output .. and it's been bothering me.  😄 